### PR TITLE
Added support for markdown files with yaml frontmatter.

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -8,17 +8,52 @@ const rimraf = require('rimraf-promise')
 const walk = require('walk')
 const yaml = require('js-yaml')
 
-const IOHelpers = function () {}
+const IOHelpers = function () { }
 
 IOHelpers.prototype.ensureDirectory = function (directory) {
   return mkdirp(directory)
+}
+
+IOHelpers.prototype.parseYamlContents = function (contents) {
+  return Promise.resolve(yaml.safeLoad(contents))
+}
+
+IOHelpers.prototype.seprateFrontMatterFromBody = function (contents) {
+  const pattern = `^---\\n([\\s\\S]*?)\\n?---\\n([\\s\\S]*)`
+  const regex = new RegExp(pattern)
+  const results = regex.exec(contents)
+  if (results) {
+    return {
+      frontMatter: results[1],
+      body: results[2]
+    }
+  } else {
+    return contents
+  }
+}
+
+IOHelpers.prototype.parseMarkdownContents = function (contents) {
+  const fmAndBody = this.seprateFrontMatterFromBody(contents)
+
+  if (fmAndBody.body && fmAndBody.frontMatter) {
+    return this.parseYamlContents(fmAndBody.frontMatter).then(ymlObject => Object.assign(
+      {},
+      ymlObject,
+      { __body: fmAndBody.body }
+    ))
+  } else {
+    return Promise.resolve(contents)
+  }
 }
 
 IOHelpers.prototype.parseFile = function (contents, extension) {
   switch (extension) {
     case '.yml':
     case '.yaml':
-      return Promise.resolve(yaml.safeLoad(contents))
+      return this.parseYamlContents(contents)
+    case '.md':
+    case '.markdown':
+      return this.parseMarkdownContents(contents)
   }
 
   return Promise.resolve(contents)

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const IOHelpers = require('./../lib/io')
+
+beforeEach(() => {
+  jest.resetModules()
+})
+
+describe('IO', () => {
+  describe('`seprateFrontMatterFromBody`', () => {
+    const seperator = '---'
+    const frontMatter =
+      'title: Title,\ntagline: Tagline,\nseperator: --- Seperator'
+    const body = 'The rest of the content.\nNew line in the rest of the content.'
+
+    const result = {
+      frontMatter: `title: Title,\ntagline: Tagline,\nseperator: --- Seperator`,
+      body: `The rest of the content.\nNew line in the rest of the content.`
+    }
+
+    test('perfect contents', () => {
+      const contents = `${seperator}\n${frontMatter}\n${seperator}\n${body}`
+      expect(IOHelpers.seprateFrontMatterFromBody(contents)).toEqual(result)
+    })
+
+    test('contents with empty frontMatter', () => {
+      const contents = `${seperator}\n${seperator}\n${body}`
+      expect(IOHelpers.seprateFrontMatterFromBody(contents).body).toEqual(result.body)
+    })
+
+    describe('funky contents returns all contents', () => {
+      test('white space before opening seperator', () => {
+        const contents = `    ${seperator}\n${frontMatter}\n${seperator}\n${body}`
+        expect(IOHelpers.seprateFrontMatterFromBody(contents)).toBe(contents)
+      })
+
+      test('no opening seperator', () => {
+        const contents = `${frontMatter}\n${seperator}\n${body}`
+        expect(IOHelpers.seprateFrontMatterFromBody(contents)).toBe(contents)
+      })
+
+      test('no closing seperator', () => {
+        const contents = `${seperator}\n${frontMatter}\n${body}`
+        expect(IOHelpers.seprateFrontMatterFromBody(contents)).toBe(contents)
+      })
+    })
+  })
+
+  describe('`parseFile()`', () => {
+
+    const ymlContent = 'budget: 58000000\ntagline: Witness the beginning of a happy ending\ntitle: Deadpool'
+    const ymlJson = {
+      budget: 58000000,
+      tagline: 'Witness the beginning of a happy ending',
+      title: 'Deadpool'
+    }
+
+    let mdContent = '---\n' + ymlContent + '\n---\nMore content with a \nnew line'
+
+    const mdJson = Object.assign(
+      {},
+      ymlJson,
+      {
+        __body: 'More content with a \nnew line'
+      }
+    )
+
+    test('parse content with .yml extention', () => {
+      expect.assertions(1)
+      return IOHelpers.parseFile(ymlContent, '.yml').then(json => expect(json).toEqual(ymlJson))
+    })
+
+    test('parse content with .yaml extention', () => {
+      expect.assertions(1)
+      return IOHelpers.parseFile(ymlContent, '.yaml').then(json => expect(json).toEqual(ymlJson))
+    })
+
+    test('parse content with .md extention', () => {
+      expect.assertions(1)
+      return IOHelpers.parseFile(mdContent, '.md').then(json => expect(json).toEqual(mdJson))
+    })
+
+    test('parse content with .markdown extention', () => {
+      expect.assertions(1)
+      return IOHelpers.parseFile(mdContent, '.markdown').then(json => expect(json).toEqual(mdJson))
+    })
+  })
+})


### PR DESCRIPTION
I have been looking for a project like this so I can have a separate repo for the content of my site. I, however, needed support for more blog style content, ie: markdown files with YAML front-matter. 

This is my attempt at solving my requirements and it might be a useful extension of your project so I am letting you know through this pull request. 

Tests have been added.